### PR TITLE
Add multi custom token support

### DIFF
--- a/backend/routes/cs-price.js
+++ b/backend/routes/cs-price.js
@@ -1,7 +1,19 @@
-// return a fix price of 50$ per token
+const manualPrices = {
+  TEST: 1 / 60,
+  SWAGTEC: 1 / 60,
+  CSLOVE: 1 / 55
+}
+
 module.exports = function (router) {
-  // This endpoint will tell the price of the CSLOVE token
-  router.get('/cs/price', async (req, res) => {
-    res.json({ CSLOVE: 1 / 55 })
+  // This endpoint will tell the price of manually configured tokens
+  router.get('/tec/price', async (req, res) => {
+    const tsyms = req.query.tsyms
+    const prices = {}
+    tsyms.split(',').map((symbol) => {
+      if (symbol in manualPrices) {
+        prices[symbol] = manualPrices[symbol]
+      }
+    })
+    res.json(prices)
   })
 }

--- a/devops/nginx/conf.d/tec.conf
+++ b/devops/nginx/conf.d/tec.conf
@@ -1,0 +1,14 @@
+server {
+    listen              443 ssl;
+    server_name         swag.tecommons.org;
+    ssl_certificate     /etc/letsencrypt/live/swag.tecommons.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/swag.tecommons.org/privkey.pem;
+
+    location / {
+        proxy_pass http://dshop-rinkeby:3001/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/shop/src/utils/useTokenDataProviders.js
+++ b/shop/src/utils/useTokenDataProviders.js
@@ -111,7 +111,7 @@ const csPriceGet = async (tokens) => {
 
   const urlBase = 'https://ogn.commonsstack.org/cs/price'
 
-  const url = process.env.TEC_PRICE_API || `${urlBase}?tsyms=${tokenSymbols}`
+  const url = process.env.CSLOVE_PRICE_API || `${urlBase}?tsyms=${tokenSymbols}`
 
   const resp = await fetch(url)
   const data = await resp.json()

--- a/shop/src/utils/useTokenDataProviders.js
+++ b/shop/src/utils/useTokenDataProviders.js
@@ -102,18 +102,16 @@ const cryptocompareGet = async (tokens) => {
   }
 }
 
-const csLoveGet = async (tokens) => {
+const csPriceGet = async (tokens) => {
   const _tokens = Array.isArray(tokens) ? tokens : [tokens]
 
   if (!_tokens.length) return {}
 
-  const tokenSymbols = _tokens.map((t) => t.name)
+  const tokenSymbols = _tokens.map((t) => t.name).join(',')
 
-  if (tokenSymbols.indexOf('CSLOVE') === -1) return {}
+  const urlBase = 'https://ogn.commonsstack.org/cs/price'
 
-  const url =
-    process.env.CSLOVE_PRICE_API ||
-    `https://ogn.commonsstack.org/cs/price?fsym=USD&tsyms=${tokenSymbols}`
+  const url = process.env.TEC_PRICE_API || `${urlBase}?tsyms=${tokenSymbols}`
 
   const resp = await fetch(url)
   const data = await resp.json()
@@ -144,8 +142,8 @@ const useTokenDataProviders = () => {
     },
     {
       id: 'cslove_oracle',
-      name: 'csLovePrice',
-      getTokenPrices: csLoveGet
+      name: 'CS Price Oracle',
+      getTokenPrices: csPriceGet
     }
   ]
 


### PR DESCRIPTION
Adds support for multiple manually configured payment tokens, currently:
- CSLOVE
- SWAGTEC

Manual token prices are configured in `backend/routes/cs-price.js`. There is probably a better place for this information, but works for now?